### PR TITLE
Skip processing the .gitmodules file when empty

### DIFF
--- a/git-submodule-url-rewrite
+++ b/git-submodule-url-rewrite
@@ -112,7 +112,7 @@ url_rewrite(){
   (
     cd "${toplevel}"
 
-    if [ ! -r "${gitmodules}" ]; then
+    if [ ! -r "${gitmodules}" ] || [ ! -s "${gitmodules}" ]; then
       return
     fi
 


### PR DESCRIPTION
With this commit, we skip processing the `.gitmodules` file when it's empty. Currently, we only skip when the file is either not readable or not existing.
In case the file is empty, the bash code doesn't expect an empty file later on and thus, leading to a failure, such as:
`Stopping at 'path/to/submoduleX'; script returned non-zero status.`